### PR TITLE
feat: show edit links

### DIFF
--- a/add_external_docs.py
+++ b/add_external_docs.py
@@ -61,19 +61,27 @@ def main():
         data = ordered_load(f, yaml.SafeLoader)
 
     with open('OUTSIDE_DOCS') as f:
-        outside_docs = [l.split(' ')[0] for l in f.readlines()]
+        outside_docs_conf = [l.strip().split(' ') for l in f.readlines()]
+
+
+    outside_docs_conf = [
+        {'name': c[0], 'repo': c[1], 'subdir': c[2]}
+        for c in outside_docs_conf
+    ]
+    outside_doc_names = [c['name'] for c in outside_docs_conf] 
 
     develop = find_entry(data['pages'], 'Develop')
     references = find_entry(develop, 'References')
 
     del references[:]
 
-    for dir in outside_docs:
+    for dir in outside_doc_names:
         abs = osp.join('./src', dir)
         toc = read_toc(dir)
         if toc:
             references.append({ dir: toc })
 
+    data['extra'] = {"outside_docs": outside_docs_conf}
     with open('mkdocs.yml', 'w+') as f:
         ordered_dump(data, f, indent=2, default_flow_style=False, Dumper=yaml.SafeDumper)
 

--- a/cozy-theme/toc.html
+++ b/cozy-theme/toc.html
@@ -1,0 +1,45 @@
+
+<div class="bs-sidebar hidden-print affix" role="complementary">
+    <ul class="nav bs-sidenav well" style='padding-left: 0; padding-right: 0; margin-bottom: 1.5rem'>
+    {%- for toc_item in page.toc %}
+        <li class="main {% if toc_item.active %}active{% endif %}"><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+        {%- for toc_item in toc_item.children %}
+            <li><a href="{{ toc_item.url }}">{{ toc_item.title }}</a></li>
+        {%- endfor %}
+    {%- endfor %}
+    </ul>
+  <div style='padding-left: 2rem'>
+    <a id='edit-link' href='{{ page.edit_url }}'>Edit documentation</a>
+    <script type='text/javascript'>
+        /* Here we detect if the current page is from an external documentation and we 
+        change the href of the editing link so it goes to the right repository and file */
+        const outsideDocs = {{ config.extra.outside_docs | tojson }}
+        const editNode = document.querySelector('#edit-link')
+        const pathname = window.location.pathname
+        const editURI = 'edit/master/'
+        const removeGitSuffix = function (x) { return x.replace(/\.git$/, '') }
+
+        // Returns the external repo associated to a pathname
+        const detectExternalRepo = function (pathname) {
+            for (var outsideDoc of outsideDocs) {
+                if (window.location.pathname.includes('/' + outsideDoc.name + '/')) {
+                    return outsideDoc
+                }
+            }
+        }
+
+        // Change the href attribute of a link to point to the correct edition page on GitHub
+        // for the passed external documentation
+        const fixEditLink = function (editNode, externalDoc) {
+            const repoFile = pathname.replace('/' + externalDoc.name, '').replace(/\/$/, '.md')
+            const baseRepo = removeGitSuffix(externalDoc.repo)
+            editNode.href = baseRepo + '/' + editURI + externalDoc.subdir + repoFile
+        }
+
+        const externalRepo = detectExternalRepo(pathname)
+        if (externalRepo) {
+            fixEditLink(editNode, externalRepo)
+        }
+    </script>
+  </div>
+</div>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,8 +3,8 @@ docs_dir: src
 site_url: https://docs.cozy.io/
 site_dir: docs/en
 site_favicon: img/favicon.png
-repo_url: https://cozy.github.io/
-edit_uri: edit/master/src/
+repo_url: https://github.com/cozy/cozy.github.io/
+edit_uri: edit/dev/src/
 site_description: Cozy documentation
 site_author: CozyCloud - https://cozy.io
 extra_css:


### PR DESCRIPTION
To facilitate the edition of the documentation (in order to have the most
up-to-date documentation), a link is added in the sidebar to edit the file
on GitHub.

##### Menu

<img width='200px' src="https://user-images.githubusercontent.com/465582/39675256-c7aa1b34-5158-11e8-8967-5e5689b7340f.png" />

##### Normal documentation

<img width='200px' src="https://user-images.githubusercontent.com/465582/39675275-0702130e-5159-11e8-8de9-f5e1645870a6.png" />

##### External repo

<img width='200px' src="https://user-images.githubusercontent.com/465582/39675259-d0bbbeee-5158-11e8-8eb7-01b7986c3a7d.png" />

To support external documentation, a small Javascript snippet detects if the
current page is for an external doc and changes the edit link to point to
the right repository.

Fix #56.