### PR TITLE
fix: add all md files to pages

### DIFF
--- a/add_external_docs.py
+++ b/add_external_docs.py
@@ -11,6 +11,17 @@ import re
 import os.path as osp
 from collections import OrderedDict
 
+import fnmatch
+import os
+
+def simple_glob(directory, glob_pattern):
+    matches = []
+    for root, dirnames, filenames in os.walk('src', followlinks=True):
+        for filename in fnmatch.filter(filenames, glob_pattern):
+            matches.append(os.path.join(root, filename))
+    return matches
+
+
 def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
     class OrderedLoader(Loader):
         pass
@@ -53,8 +64,34 @@ def read_toc(directory):
             make_paths_absolute(toc)
             return toc
 
+
 def find_entry(tree, name):
     return [p for p in tree if p.get(name)][0][name]
+
+
+def walk_dict(d):
+    it = None
+    if isinstance(d, list):
+        it = iter(d)
+    elif isinstance(d, dict):
+        it = d.itervalues()
+    if it:
+        for item in it:
+            for leaf in walk_dict(item):
+                yield leaf
+    else:
+        yield d
+
+
+def find_not_referenced(tocs):
+    files = set([f.replace('src/', '') for f in simple_glob('src', '*.md')])
+    referenced_files = set([r for toc in tocs for r in walk_dict(toc)])
+    return list(files - referenced_files)
+
+
+def get_name(filename):
+    return '.'.join(osp.basename(filename).split('.')[:-1])
+
 
 def main():
     with open('./mkdocs.yml') as f:
@@ -62,8 +99,6 @@ def main():
 
     with open('OUTSIDE_DOCS') as f:
         outside_docs_conf = [l.strip().split(' ') for l in f.readlines()]
-
-
     outside_docs_conf = [
         {'name': c[0], 'repo': c[1], 'subdir': c[2]}
         for c in outside_docs_conf
@@ -75,13 +110,17 @@ def main():
 
     del references[:]
 
+    tocs = []
     for dir in outside_doc_names:
         abs = osp.join('./src', dir)
         toc = read_toc(dir)
         if toc:
             references.append({ dir: toc })
+        tocs.append(toc)
 
+    data['pages'].append({'hidden': [{get_name(k): k} for n, k in enumerate(sorted(find_not_referenced(tocs)))]})
     data['extra'] = {"outside_docs": outside_docs_conf}
+
     with open('mkdocs.yml', 'w+') as f:
         ordered_dump(data, f, indent=2, default_flow_style=False, Dumper=yaml.SafeDumper)
 

--- a/cozy-theme/nav.html
+++ b/cozy-theme/nav.html
@@ -26,7 +26,7 @@
             {%- if nav|length>1 %}
                 <!-- Main navigation -->
                 <ul class="nav navbar-nav">
-                {%- for nav_item in nav %}
+                {%- for nav_item in nav if not nav_item.title == 'hidden' %}
                 {%- if nav_item.children %}
                     <li class="dropdown{% if nav_item.active %} active{% endif %}">
                         <a href="#" class="dropdown-toggle" data-toggle="dropdown">{{ nav_item.title }} <b class="caret"></b></a>


### PR DESCRIPTION
Since some markdown files in external docs were not present in the
pages (because they are not in any table of contents), they were not
built by mkdocs and this would cause 404.

In this PR, files that are not present in pages but are present on the
filesystem are automatically added to a `hidden` section in pages.

This `hidden` section is not displayed in the nav (this is
by filtering directly in the template).