### PR TITLE
Remove l18n

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,10 @@ This documentation is built with [MkDocs](http://www.mkdocs.org).
 
 To edit the documentation, just edit the files inside `src`.
 
-If you want to see your updates, install mkdocs and the i18n extension of markdown:
-
-_Warning: while mkdocs supports Python 2 and 3, the current version of markdown-i18n only support Python 2_
+If you want to see your updates, install mkdocs:
 
 ```shell
-pip install --user mkdocs markdown-i18n
+pip install --user mkdocs
 ```
 
 Fetch external documentation and add it to mkdocs.yml (do not commit this the changes in `References`) :
@@ -51,25 +49,6 @@ The documentation is built automatically by Travis
 
 After the build, it is available on https://docs.cozy.io/.
 
-## i18n
-
-To add a new language, copy `mkdocs.yml` to `mkdocs_lang.yml`, translate the pages title and update `site_dir` and `markdown_extensions.markdown_i18n.i18n_lang`.
-
-You’ll require some Gettext utilities. On Debian GNU/Linux, install the `gettext` package.
-
-Every time you run a build, MkDocs will update the `i18n/messages.pot` file.
-
-When adding a new language, you first need to initialize the `.po` file. For example, for french translation:
-
-```shell
-msginit --input=./i18n/messages.pot --output=./i18n/fr_FR/LC_MESSAGES/messages.po
-```
-
-To build the French version of the website:
-
-```shell
-mkdocs build -f mkdocs_fr.yml --clean
-```
 
 To test the whole site:
 
@@ -77,13 +56,7 @@ To test the whole site:
 rm -rf docs/*
 cp index.html docs/
 mkdocs build -f mkdocs.yml
-mkdocs build -f mkdocs_fr.yml
 cd site/
 python -m SimpleHTTPServer
 ```
 
-To update the translation file, use `msgmerge`:
-
-```shell
-msgmerge --update i18n/fr_FR/LC_MESSAGES/messages.po i18n/messages.pot
-```

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,3 @@ cp CNAME docs/
 python add_external_docs.py
 
 mkdocs build -f mkdocs.yml
-mkdocs build -f mkdocs_fr.yml
-msgmerge --update i18n/fr_FR/LC_MESSAGES/messages.po i18n/messages.pot
-
-# Override french developer documentation with the up to date english version
-cp -R docs/en/dev/ docs/fr/
-

--- a/cozy-theme/nav.html
+++ b/cozy-theme/nav.html
@@ -15,8 +15,6 @@
 
           {%- block site_name %}
             <a class="navbar-brand" href="https://docs.cozy.io/">{{ config.site_name }}</a>
-            <a class="navbar-brand" href="https://docs.cozy.io/en">en</a>
-            <a class="navbar-brand" href="https://docs.cozy.io/fr/index_fr">fr</a>
           {%- endblock %}
         </div>
 

--- a/index.html
+++ b/index.html
@@ -4,16 +4,7 @@
         <meta charset="UTF-8">
         <meta http-equiv="refresh" content="1; url=en/">
         <script type="text/javascript">
-
-        var language = navigator.language || navigator.browserLanguage; //for IE
-
-        // alert(language);
-
-        if (language.indexOf('fr') > -1) {
-          window.location.href = '/fr/index_fr/';
-        } else {
-          window.location.href = '/en/';
-        }
+        window.location.href = '/en/';
         </script>
         <title>Page Redirection</title>
     </head>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,9 +41,6 @@ markdown_extensions:
   - extra
   - footnotes
   - meta
-  #- markdown_i18n:
-  #    i18n_lang: en_US
-  #    i18n_dir: i18n
   - sane_lists
   - smarty
   - toc:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 -e git+https://github.com/mkdocs/mkdocs.git@3f0e446#egg=mkdocs
-markdown-i18n
 pyyaml


### PR DESCRIPTION
As for now the documentation will only host technical papers, so it will
be english only.
Remove everything that was used to translate it into other languages.