### PR TITLE
Konnectors: enable user namespaces

### DIFF
--- a/src/install/debian.md
+++ b/src/install/debian.md
@@ -162,6 +162,12 @@ If you want to use konnectors, you need to initialize the NodeJS chroot
 /usr/share/cozy/konnector-create-chroot.sh
 ```
 
+You also need to enable user namespaces:
+
+```bash
+sysctl -w kernel.unprivileged_userns_clone=1
+```
+
 If you use a self-signed certificate or a not official certificate authority, you need to deploy the corresponding root certificate in `/usr/share/cozy/chroot/etc/ssl/certs/custom.crt`.  
 For example, if you use [Let's Encrypt staging environment](https://letsencrypt.org/docs/staging-environment/) for testing purpose :
 


### PR DESCRIPTION
Tell user to enable user namespaces on Debian for konnectors