### PR TITLE
docs: Explain what cozy-scripts start does

### DIFF
--- a/src/tutorials/app.md
+++ b/src/tutorials/app.md
@@ -60,19 +60,26 @@ The script will download some dependencies (may take a while) and ask you a few 
   <img src="../../img/dev/cca-create.gif" />
 </div>
 
-That's it! You can already start hacking:
+That's it! You can already start developing:
 
 ```
 cd mycozyapp
 yarn start
 ```
 
-After the webpack build and the Cozy inside Docker is started, the app `mycozyapp` app should be available at `http://mycozyapp.cozy.tools:8080` (the password is `cozy`), as noticed by the output:
+This command will run 
+
+- `webpack` in a watching mode with a server (webpack-dev-server) to serve application assets.
+- a Cozy `stack` using docker (the image `cozy/cozy-app-dev`) to serve your application inside it.
+- The same docker image starts a CouchDB containing your data (be careful, since a data volume is not attached by default, your data will disappear on restart. You should start the docker image manually if you want to persist your data).
+
+Your application will be available at http://<MY_APP_SLUG>.cozy.tools:8080. Password is `cozy`.
+
+    In this mode HMR (Hot Module Replacement) is available to help you with the application development.
 
 <div align="center">
   <img src="../../img/dev/cca-start.gif" />
 </div>
-
 
 ---
 


### PR DESCRIPTION
There was no explanation that `cozy-scripts start` starts a stack/couchdb.