### PR TITLE
fix: External edit links work

### DIFF
--- a/src/extra.js
+++ b/src/extra.js
@@ -27,6 +27,18 @@ var setupSearchHotkey = function () {
   document.addEventListener('keydown', checkForSearchSlash)
 }
 
+const removeGitSuffix = function (x) { return x.replace(/\.git$/, '') }
+
+// Returns the external repo associated to a pathname
+const detectExternalRepo = function (pathname) {
+  // window.outsideDocs is defined in main.html
+  for (var outsideDoc of window.outsideDocs) {
+    if (window.location.pathname.includes('/' + outsideDoc.name + '/')) {
+      return outsideDoc
+    }
+  }
+}
+
 /**
  * Change the href of the edit link for docs that are pulled from outside the main doc repository
  */
@@ -35,28 +47,14 @@ const fixEditLinkIfNecessary = function () {
   change the href of the editing link so it goes to the right repository and file */
   const editNode = document.querySelector('[title="Edit this page"]')
   const pathname = window.location.pathname
-  const editURI = 'edit/master/'
-  const removeGitSuffix = function (x) { return x.replace(/\.git$/, '') }
-
-  // Returns the external repo associated to a pathname
-  const detectExternalRepo = function (pathname) {
-    // window.outsideDocs is defined in main.html
-    for (var outsideDoc of window.outsideDocs) {
-      if (window.location.pathname.includes('/' + outsideDoc.name + '/')) {
-        return outsideDoc
-      }
-    }
-  }
+  const editURI = 'edit/master'
 
   // Change the href attribute of a link to point to the correct edition page on GitHub
   // for the passed external documentation
   const fixEditLink = function (editNode, externalDoc) {
-    const inDev = window.location.host.includes('localhost')
-    const prefix = inDev ? '/' : '/en/'
-    const isReadme = document.title.includes('README')
-    const repoFile = pathname.replace(prefix + externalDoc.name, '').replace(/\/$/, isReadme ? '/README.md' : '.md')
+    const filePath = editNode.href.replace(/.*\/src\//, '').replace(externalDoc.name + '/', externalDoc.subdir + '/')
     const baseRepo = removeGitSuffix(externalDoc.repo)
-    const href = baseRepo + '/' + editURI + externalDoc.subdir + repoFile
+    const href = baseRepo + '/' + editURI + '/' + filePath
     editNode.href = href
   }
 

--- a/src/extra.js
+++ b/src/extra.js
@@ -52,6 +52,8 @@ const fixEditLinkIfNecessary = function () {
   // Change the href attribute of a link to point to the correct edition page on GitHub
   // for the passed external documentation
   const fixEditLink = function (editNode, externalDoc) {
+    // We base ourselves on the original href which contains the information on the path of the file.
+    // We have to add the subdir though.
     const filePath = editNode.href.replace(/.*\/src\//, '').replace(externalDoc.name + '/', externalDoc.subdir + '/')
     const baseRepo = removeGitSuffix(externalDoc.repo)
     const href = baseRepo + '/' + editURI + '/' + filePath


### PR DESCRIPTION
External READMEs edit links were not always working, now they do work