### PR TITLE
Add cozy-banks documentation

### DIFF
--- a/OUTSIDE_DOCS
+++ b/OUTSIDE_DOCS
@@ -14,3 +14,4 @@ cozy-device-helper https://github.com/cozy/cozy-libs.git packages/cozy-device-he
 eslint-config-cozy-app https://github.com/cozy/cozy-libs.git packages/eslint-config-cozy-app
 cozy-flags https://github.com/cozy/cozy-libs.git packages/cozy-flags
 cozy-realtime https://github.com/cozy/cozy-libs.git packages/cozy-realtime
+cozy-banks https://github.com/cozy/cozy-banks.git .

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -65,6 +65,8 @@ theme:
   font:
     text: Lato
     code: Ubuntu Mono
+  feature:
+    tabs: true
 markdown_extensions:
 - admonition
 - codehilite

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,8 @@ nav:
   - Advanced:
     - Stack server: <cozy-stack>
     - Registry server: <cozy-apps-registry>
+- Applications:
+  - Cozy Banks: <cozy-banks>
 theme:
   custom_dir: cozy-theme
   name: material


### PR DESCRIPTION
Introduce an "Applications" part, containing only cozy banks for now.

Also use the tabs layout from mkdocs-material (see https://squidfunk.github.io/mkdocs-material/getting-started/#tabs):

![image](https://user-images.githubusercontent.com/1606068/63862685-47a48400-c9ad-11e9-90f7-e7adb9872676.png)