### PR TITLE
Change order of the links inside "libraries"

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,9 +35,9 @@ nav:
     - Install Cozy Drive on GNU/Linux: howTos/sync/linux.md
 - Libraries:
   - Develop an application:
-    - Define data (doctypes): <cozy-doctypes>
     - Access data (client): <cozy-client>
     - Build a UI (ui): <cozy-ui>
+    - Define data (doctypes): <cozy-doctypes>
     - Advanced:
       - Realtime data (realtime): <cozy-realtime>
       - Native devices (device-helper): <cozy-device-helper>


### PR DESCRIPTION
Par défaut on tombe sur le README des doctypes, et une très longue liste de doctype. Il me semble plus pertinent de tomber sur quelque chose de plus actif et plus court, j'ai donc inversé l'ordre.