### PR TITLE
feat: Add cozy-coclyco to the documentation

### DIFF
--- a/OUTSIDE_DOCS
+++ b/OUTSIDE_DOCS
@@ -16,3 +16,4 @@ cozy-flags https://github.com/cozy/cozy-libs.git packages/cozy-flags
 cozy-realtime https://github.com/cozy/cozy-libs.git packages/cozy-realtime
 cozy-banks https://github.com/cozy/cozy-banks.git .
 ach https://github.com/cozy/ach.git .
+cozy-coclyco https://github.com/cozy/cozy-coclyco.git .


### PR DESCRIPTION
Add at least cozy-coclyco to the main entry. 

Next : better integration with the self hosted page?

`cozy-coclyco` is designed to create Cozy instances, manage nginx vhost and Let's encrypt certificate issuance.