### PR TITLE
feat: Update MarkupSafe

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ jsx-lexer==0.0.6
 livereload==2.5.2
 Markdown==3.2
 markdown-i18n==2.1.2
-MarkupSafe==1.0
+MarkupSafe==1.1
 packaging==18.0
 pip-upgrader==1.4.6
 Pygments==2.2.0


### PR DESCRIPTION
Uses a deprecated export from setuptools that causes an
error on the CI