### PR TITLE
feat: handle words with _ in the search engine

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -218,4 +218,4 @@ extra:
     repo: https://github.com/cozy/ach.git
     subdir: .
   search:
-    tokenizer: "[^a-z\u0430-\u044F\u04510-9\\-\\.]"
+    tokenizer: "[^a-z\u0430-\u044F\u04510-9\\-\\._]"


### PR DESCRIPTION
Words like time_interval are could not be found in the search engine until now.