### PR TITLE
Fix broken links

### DIFF
--- a/mkdocs.yml.tpl
+++ b/mkdocs.yml.tpl
@@ -89,7 +89,6 @@ extra:
     tokenizer: "[^a-z\u0430-\u044F\u04510-9\\-\\.]"
 plugins:
     - search
-    - exclude:
-        glob:
-          - "cozy-stack/archives/*"
-
+    - exclude-search:
+        exclude:
+          - cozy-stack/archives/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ urllib3==1.24.2
 mkdocs==1.0.4
 mkdocs-material==4.4.0
 mkdocs-exclude==1.0.2
+mkdocs-exclude-search==0.5.4

--- a/src/references/tech-intro.md
+++ b/src/references/tech-intro.md
@@ -33,7 +33,7 @@ Several layers can be distinguished. From inside to outside:
 
 ## The server (Cozy-stack - [documentation](https://docs.cozy.io/en/cozy-stack/))
 
-The server consist of a single process. We call it _the Cozy stack_. 
+The server consist of a single process. We call it _the Cozy stack_.
 
 The server is in charge of serving the Web applications users have installed from the application store.
 
@@ -98,6 +98,6 @@ We use _Content Security Policy_ to control what the application is allowed to d
 
 - Coding tutorials :
   - [Create a client application](../tutorials/app.md)
-  - [Develop a connector](../tutorials/konnector.md).
+  - [Develop a connector](../tutorials/konnector/index.md).
 - Selfhosting : [How to to self-host a Cozy server](../tutorials/selfhost-debian.md)
 - The [cozy server documentation](https://docs.cozy.io/en/cozy-stack/) (cozy-stack)


### PR DESCRIPTION
- Do not exclude cozy-stack/docs/archives because they are referenced from other cozy-stack documentations
- Fix broken link to konnector tutorial