### PR TITLE
Fix/selfhost ubuntu documentation typos and homogenization

### DIFF
--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
@@ -26,25 +26,25 @@ During installation, you will also define:
 
 # Couchdb
 
-Configure CouchDB package repository
+Configure CouchDB package repository:
 
     sudo apt update && sudo apt install -y curl apt-transport-https gnupg
     curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
     echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
-Install Couchdb
+Install Couchdb:
 
     sudo apt update
     sudo apt install -y couchdb
 
 Duing CouchDB installation, choose `Standalone` mode and define admin password.
 
-Validate CouchDB is working
+Validate CouchDB is working:
 
     curl http://localhost:5984/
     {"couchdb":"Welcome","version":"3.2.1","git_sha":"244d428af","uuid":"f7b83554fa2eb43778963d18a1f92211","features":["access-ready","partitioned","pluggable-storage-engines","reshard","scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
 
-Finally, create a database user and password for  cozy-stack
+Finally, create a database user and password for  cozy-stack:
 
     read -p "Couchdb password for cozy user: " -r -s COUCH_PASS
     curl -fsX PUT -u "admin:adminpwd" "http://localhost:5984/_node/couchdb@127.0.0.1/_config/admins/cozy" --data "\"${COUCH_PASS}\""
@@ -55,14 +55,14 @@ In this command line, `adminpwd` should be replaced by CouchDB admin password yo
 
 To be able to run cozy connectors and gather all your data, cozy-stack needs NodeJS version 12 or 16. This documents gives instructions to instal NodeJS 16.
 
-Configure NodeJS 16 package repository
+Configure NodeJS 16 package repository:
 
     KEYRING=/usr/share/keyrings/nodesource.gpg
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee "$KEYRING" >/dev/null
     echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/node_16.x $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
     echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/node_16.x $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list >/dev/null
 
-Install NodeJS
+Install NodeJS:
 
     sudo apt update
     sudo apt install -y nodejs
@@ -70,49 +70,49 @@ Install NodeJS
 
 # Go
 
-cozy-stack is developped in Go language so we need to install the go compiler to be able to compile cozy-stack sources.
+cozy-stack is developped in Go language so we need to install the go compiler to be able to compile cozy-stack sources:
 
     wget -O /tmp/go1.17.3.linux-amd64.tar.gz https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
     sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzvf /tmp/go1.17.3.linux-amd64.tar.gz
     echo "export PATH=\"\$PATH:/usr/local/go/bin\"" | sudo tee /etc/profile.d/golang.sh > /dev/null
     source /etc/profile.d/golang.sh
 
-Test Go installation is fine with
+Test Go installation is fine with:
 
     go version
     go version go1.17.3 linux/amd64
 
 # Cozy-stack
 
-First, install requirements
+First, install requirements:
 
     sudo apt install -y imagemagick libprotobuf-c1 fonts-lato
 
-Get the source code
+Get the source code:
 
     sudo apt install -y git
     sudo git clone https://github.com/cozy/cozy-stack.git /opt/cozy-stack
 
-Then compile the program
+Then compile the program:
 
     cd /opt/cozy-stack
     scripts/build.sh release $(go env GOPATH)/bin/cozy-stack
 
 The compilation generate a binary file under `$GOPATH/bin/cozy-stack`
 
-You can test it with :
+You can test it with:
 
     $(go env GOPATH)/bin/cozy-stack version
     1.5.0-5-gcbdf012d
 
-You then have to create a user to run cozy-stack
+You then have to create a user to run cozy-stack:
 
     sudo addgroup --quiet --system cozy
     sudo adduser --quiet --system --home /var/lib/cozy \
                  --no-create-home --shell /usr/sbin/nologin \
                  --ingroup cozy cozy-stack
 
-And install it
+And install it:
 
     sudo install -o root -g root -m 0755 -T \
                  $(go env GOPATH)/bin/cozy-stack /usr/bin/cozy-stack
@@ -127,7 +127,7 @@ And install it
     sudo install -o cozy-stack -g cozy -m 750 -d /var/lib/cozy
 
 
-And create configuration
+And create configuration:
 
     read -p "Cozy stack admin password: " -r -s COZY_PASS
     cat <<EOF | sudo tee /etc/cozy/cozy.yml >/dev/null
@@ -169,7 +169,7 @@ And create configuration
     sudo chown cozy-stack:cozy /etc/cozy/vault.enc /etc/cozy/vault.dec
     sudo chmod 0600 /etc/cozy/vault.enc /etc/cozy/vault.dec
 
-Finally, configure systemd to automatically launch cozy-stack on boot.
+Finally, configure systemd to automatically launch cozy-stack on boot:
 
     cat <<EOF | sudo tee /usr/lib/systemd/system/cozy-stack.service >/dev/null
     [Unit]
@@ -192,30 +192,30 @@ Finally, configure systemd to automatically launch cozy-stack on boot.
     sudo systemctl enable cozy-stack
     sudo systemctl start cozy-stack
 
-You can validate everything went well and cozy-stack is running thiw way
+You can validate everything went well and cozy-stack is running thiw way:
 
     curl http://localhost:8080/version
     {"build_mode":"production","build_time":"2021-12-01T13:12:36Z","runtime_version":"go1.17.3","version":"1.5.0-5-gcbdf012d"}
 
 # Nginx
 
-First create a DNS entry in your domain for `cozy.domain.example` and `*.cozy.domain.example` pointing at your server. For example :
+First create a DNS entry in your domain for `cozy.domain.example` and `*.cozy.domain.example` pointing at your server. For example:
 
 
     cozy     1h     IN         A     <your_server_IP>
     *.cozy   1h     IN     CNAME     cozy
 
-Then install Nginx
+Then install Nginx:
 
     sudo apt install -y nginx certbot
 
-Generate SSL certificate with certbot
+Generate SSL certificate with certbot:
 
     DOMAIN=domain.example
     EMAIL="<your email address>"
     sudo certbot certonly --email "${EMAIL}" --non-interactive --agree-tos --webroot -w /var/www/html -d cozy.${DOMAIN} $(printf -- " -d %s.cozy.${DOMAIN}" home banks contacts drive notes passwords photos settings store)
 
-Create nginx reload script for your certificate to be reloaded each time it is automatically refreshed, every 3 months
+Create nginx reload script for your certificate to be reloaded each time it is automatically refreshed, every 3 months:
 
     cat <<EOF | sudo tee /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
     #!/bin/bash
@@ -223,7 +223,7 @@ Create nginx reload script for your certificate to be reloaded each time it is a
     EOF
     chmod 0755 /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
 
-Configure nginx
+Configure nginx:
 
     DOMAIN=domain.example
     cat <<EOF | sudo tee /etc/nginx/sites-available/cozy.${DOMAIN} > /dev/null
@@ -273,7 +273,7 @@ You can then test from your browser by visiting `https://cozy.domain.example` an
 
 # Cozy instance creation
 
-Create your cozy instance
+Create your cozy instance:
 
     DOMAIN=domain.example
     EMAIL=<your email address>
@@ -299,24 +299,24 @@ Having its own selfhosted cozy instance is nice but hosting cozy instances for f
 
 The first cozy instance we added was `https://cozy.domain.example`. We will create a second cozy instance for Mary with address `https://mary.domain.example` (Replace `domain.example` with your own domain name and `mary` whith what you want to uniquely identify the cozy instance.
 
-So we will need :
+So we will need:
 
 - Our domain name. We still use `domain.example` in this documentation
 - The new cozy instance's “slug”, which is its unique identifier. We will use `mary` here for example. The address for this new cozy instance will the be in the form `https://<slug>.<domain>`, for example here `https://mary.domain.example`
 
-First, let's put all that important information in variables
+First, let's put all that important information in variables:
 
     DOMAIN=domain.example
     EMAIL=<your email addresse>
     NEWSLUG=mary
     NEWEMAIL=<Mary's email address>
 
-Create DNS entries for this cozy isntance. For example :
+Create DNS entries for this cozy isntance. For example:
 
     mary     1h     IN         A     <your_server_IP>
     *.mary   1h     IN     CNAME     mary
 
-Create Nginx base configuration for this cozy isntance
+Create Nginx base configuration for this cozy isntance:
 
     cat <<EOF | sudo tee /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
     server {
@@ -338,11 +338,11 @@ Create Nginx base configuration for this cozy isntance
     sudo ln -s ../sites-available/${NEWSLUG}.${DOMAIN} /etc/nginx/sites-enabled/
     sudo systemctl reload nginx
 
-Generate SSL certificate using certbot
+Generate SSL certificate using certbot:
 
     sudo certbot certonly --email "${EMAIL}" --non-interactive --agree-tos --webroot -w /var/www/html -d ${NEWSLUG}.${DOMAIN} $(printf -- " -d %s.${NEWSLUG}.${DOMAIN}" home banks contacts drive notes passwords photos settings store)
 
-Finalize Nginx configuration
+Finalize Nginx configuration:
 
     cat <<EOF | sudo tee -a /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
 
@@ -371,7 +371,7 @@ Finalize Nginx configuration
     EOF
     sudo systemctl reload nginx
 
-Create cozy instance
+Create cozy instance:
 
     [[ -z "${COZY_PASS}" ]] && read -p "Cozy stack admin password: " -r -s COZY_PASS
     COZY_ADMIN_PASSWORD="${COZY_PASS}" cozy-stack instances add --apps home,banks,contacts,drive,notes,passwords,photos,settings,store --email "${NEWEMAIL}" --locale fr --tz "Europe/Paris" ${NEWSLUG}.${DOMAIN}
@@ -431,17 +431,17 @@ Then restart Nginx
 
 ### Configure HTTPS for OnlyOffice
 
-Create a DNS entry for OnlyOffice targetting your server. For example :
+Create a DNS entry for OnlyOffice targetting your server. For example:
 
     onlyoffice     1h     IN         A     <your_server_IP>
 
-Generate SSL certificate
+Generate SSL certificate:
 
     EMAIL=<your email address>
     DOMAIN=domain.example
     sudo bash /usr/bin/documentserver-letsencrypt.sh "${EMAIL}" "onlyoffice.${DOMAIN}"
 
-Configure onlyoffice
+Configure onlyoffice:
 
     sudo cp -f /etc/onlyoffice/documentserver/nginx/ds-ssl.conf.tmpl /etc/onlyoffice/documentserver/nginx/ds.conf
 
@@ -452,7 +452,7 @@ Edit file `/etc/onlyoffice/documentserver/nginx/ds.conf` and
 
 Be careful each line end with semicolons (`;`).
 
-Restart OnlyOffice and Nginx
+Restart OnlyOffice and Nginx:
 
     sudo supervisorctl restart all
     sudo systemctl restart nginx
@@ -462,7 +462,7 @@ You can now test onlyoffice is accessible from your browser at `https://onlyoffi
 
 ## Configure cozy-stack for OnlyOffice
 
-Update configuration file
+Update configuration file:
 
     DOMAIN=domain.example
     cat <<EOF | sudo tee -a /etc/cozy/cozy.yml > /dev/null
@@ -471,11 +471,11 @@ Update configuration file
         onlyoffice_url: https://onlyoffice.${DOMAIN}/
     EOF
 
-Restart cozy-stack
+Restart cozy-stack:
 
     sudo systemctl restart cozy-stack
 
-Activate functionality
+Activate functionality:
 
     cozy-stack features defaults '{"drive.onlyoffice.enabled": true}'
 
@@ -487,27 +487,27 @@ You can now upload an office document in cozy-drive and start editing it online 
 Applications inside your cozy are automatically updated, however, cozy-stack application running on your server must be updated from time to time (once every 3 month is a good compromise between too much and too few).
 Here is how to upgrade cozy-stack:
 
-Update source code
+Update source code:
 
     cd /opt/cozy-stack
     sudo git pull
 
-compile source code
+compile source code:
 
     cd /opt/cozy-stack
     scripts/build.sh release $(go env GOPATH)/bin/cozy-stack
 
-You can test compilation produced a valid binary with
+You can test compilation produced a valid binary with:
 
     $(go env GOPATH)/bin/cozy-stack version
     1.5.0-9-g1eac6802
 
-Install new generated binary
+Install new generated binary:
 
     sudo install -o root -g root -m 0755 -T \
                  $(go env GOPATH)/bin/cozy-stack /usr/bin/cozy-stack             
 
-Restart cozy-stack
+Restart cozy-stack:
 
     sudo systemctl restart cozy-stack
 

--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
@@ -19,7 +19,7 @@ The installation procedure requires:
 
 During installation, you will also define:
 
-- a CouchDB admininstration password
+- a CouchDB administration password
 - a CouchDB database access password
 - a cozy-stack admin password
 - You will need to provide your email address for Let's Encrypt SSL certificate validation and your Cozy instance creation
@@ -70,7 +70,7 @@ Install NodeJS:
 
 # Go
 
-cozy-stack is developped in Go language so we need to install the go compiler to be able to compile cozy-stack sources:
+cozy-stack is developped in Go language so we need to install the Go compiler to be able to compile cozy-stack sources:
 
     wget -O /tmp/go1.17.3.linux-amd64.tar.gz https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
     sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzvf /tmp/go1.17.3.linux-amd64.tar.gz
@@ -295,9 +295,9 @@ Below are some bonuses 😉
 
 # Hosting more than one Cozy instance on the same server
 
-Having its own selfhosted Cozy instance is nice but hosting Cozy instances for friends and familly is a must! Here is how to add more Cozy instances on the same server.
+Having its own selfhosted Cozy instance is nice but hosting Cozy instances for friends and family is a must! Here is how to add more Cozy instances on the same server.
 
-The first Cozy instance we added was `https://cozy.domain.example`. We will create a second Cozy instance for Mary with address `https://mary.domain.example` (Replace `domain.example` with your own domain name and `mary` whith what you want to uniquely identify the Cozy instance.
+The first Cozy instance we added was `https://cozy.domain.example`. We will create a second Cozy instance for Mary with address `https://mary.domain.example` (Replace `domain.example` with your own domain name and `mary` with what you want to uniquely identify the Cozy instance.
 
 So we will need:
 
@@ -311,12 +311,12 @@ First, let's put all that important information in variables:
     NEWSLUG=mary
     NEWEMAIL=<Mary's email address>
 
-Create DNS entries for this Cozy isntance. For example:
+Create DNS entries for this Cozy instance. For example:
 
     mary     1h     IN         A     <your_server_IP>
     *.mary   1h     IN     CNAME     mary
 
-Create Nginx base configuration for this Cozy isntance:
+Create Nginx base configuration for this Cozy instance:
 
     cat <<EOF | sudo tee /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
     server {
@@ -379,11 +379,11 @@ Create Cozy instance:
 Note the “Registration token” the last command gives you and send Mary the following url: `https://mary.domain.example?registerToken=<registration_token>`, substituting `domain.example` with your own domain name, `mary` with the slug you chose for this new instance and  `<registration_token>` with the “Registration token” returned by the last command.
 By visiting this address with her browser, Mary will be able to define its password and start using her Cozy.
 
-# Online edtion of office documents
+# Online edition of office documents
 
 Online office document edition functionality based on OnlyOffice is optional. You can use your Cozy without activating it. It let you edit your office documents online directly in your browser, however it requires more resources on your server.
 
-To activate this functionality, you need to install OnlyOffice document server and configure cozy-stack to access it. OnlyOffice document server can be isntalled on the same server or on another server at your convenience. This documentation explain how to install it on the same server.
+To activate this functionality, you need to install OnlyOffice document server and configure cozy-stack to access it. OnlyOffice document server can be installed on the same server or on another server at your convenience. This documentation explain how to install it on the same server.
 
 
 ## Onlyoffice
@@ -431,7 +431,7 @@ Then restart Nginx
 
 ### Configure HTTPS for OnlyOffice
 
-Create a DNS entry for OnlyOffice targetting your server. For example:
+Create a DNS entry for OnlyOffice targeting your server. For example:
 
     onlyoffice     1h     IN         A     <your_server_IP>
 
@@ -511,7 +511,7 @@ Restart cozy-stack:
 
     sudo systemctl restart cozy-stack
 
-Et voilà, you just upgraded cozy-stack to the latest verson. pretty easy.
+Et voilà, you just upgraded cozy-stack to the latest version. pretty easy.
 
 # References
 - CouchDB installation: [https://docs.couchdb.org/en/stable/install/unix.html](https://docs.couchdb.org/en/stable/install/unix.html)

--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
@@ -1,10 +1,10 @@
-# Install cozy on Ubuntu 20.04 LTS focal fossa
+# Install Cozy on Ubuntu 20.04 LTS focal fossa
 
 # Introduction
 
 Cozycloud provides Debian packages and [installation instructions](https://docs.cozy.io/en/tutorials/selfhosting/selfhost-debian-pkg/) for Debian 10 buster from installation packages. However, there is no published packages for Ubuntu.
 
-This documentation describes how to install cozy from sources on an Ubuntu 20.04 LTS focal fossa server. We will also see how to host multiple cozy instances on the same server, how to activate online edition for office documents and how to upgrade cozy-stack.
+This documentation describes how to install Cozy from sources on an Ubuntu 20.04 LTS focal fossa server. We will also see how to host multiple Cozy instances on the same server, how to activate online edition for office documents and how to upgrade cozy-stack.
 
 
 # Requirements
@@ -12,9 +12,9 @@ This documentation describes how to install cozy from sources on an Ubuntu 20.04
 The installation procedure requires:
 
 - An Ubuntu 20.04 LTS focal fossa server
-- A domain name (mandatory to host cozy instances secured with https and accessible from internet).
+- A domain name (mandatory to host Cozy instances secured with https and accessible from internet).
     In this docuemnt, we will use `domain.example` as an example. You will replace it with your own domain name throughout the explanation.
-    The address of your cozy instance will be `cozy.domain.example`
+    The address of your Cozy instance will be `cozy.domain.example`
 - Good system administration knowledge. Despite documentation's goal is to be pretty straightforward to follow, there are some tricky and technical parts.
 
 During installation, you will also define:
@@ -22,7 +22,7 @@ During installation, you will also define:
 - a CouchDB admininstration password
 - a CouchDB database access password
 - a cozy-stack admin password
-- You will need to provide your email address for Let's Encrypt SSL certificate validation and your cozy instance creation
+- You will need to provide your email address for Let's Encrypt SSL certificate validation and your Cozy instance creation
 
 # Couchdb
 
@@ -53,7 +53,7 @@ In this command line, `adminpwd` should be replaced by CouchDB admin password yo
 
 # NodeJS
 
-To be able to run cozy connectors and gather all your data, cozy-stack needs NodeJS version 12 or 16. This documents gives instructions to instal NodeJS 16.
+To be able to run Cozy connectors and gather all your data, cozy-stack needs NodeJS version 12 or 16. This documents gives instructions to instal NodeJS 16.
 
 Configure NodeJS 16 package repository:
 
@@ -269,11 +269,11 @@ Configure nginx:
     sudo ln -s ../sites-available/cozy.${DOMAIN} /etc/nginx/sites-enabled/
     sudo systemctl reload nginx
 
-You can then test from your browser by visiting `https://cozy.domain.example` and you should see a page telling you this cozy instance doesn't exist yet. This is the sign that everything went well and the only part left is to create the instance.
+You can then test from your browser by visiting `https://cozy.domain.example` and you should see a page telling you this Cozy instance doesn't exist yet. This is the sign that everything went well and the only part left is to create the instance.
 
 # Cozy instance creation
 
-Create your cozy instance:
+Create your Cozy instance:
 
     DOMAIN=domain.example
     EMAIL=<your email address>
@@ -283,26 +283,26 @@ Create your cozy instance:
 You can of course adapt your language (`locale`) and choose english (`en`) or spanish (`es`) and choose another timezone (`tz`).
 
 Note the “Registration token” this command returns and visit from your browser `https://cozy.domain.example?registerToken=<registration_token>` substituting `domain.example` with your real domain name and `<registration_token>` with the “Registration token” you got.
-You will be prompted to define your cozy password and you will be able to start using your self-hosted cozy.
+You will be prompted to define your Cozy password and you will be able to start using your self-hosted Cozy.
 
 
 # Et voilà !
 
-Your cozy is not fully operational! Its address is `https://cozy.domain.example` (remplace `domain.example` by your own domain name)
-You can then start installing connectors from store to automatically gather your data, save your passwords in cozy-pass, store your files in cozy-drive and install cozy-desktop client on your PC to synchronize your cozy content with a local folder.
+Your Cozy is not fully operational! Its address is `https://cozy.domain.example` (remplace `domain.example` by your own domain name)
+You can then start installing connectors from store to automatically gather your data, save your passwords in cozy-pass, store your files in cozy-drive and install cozy-desktop client on your PC to synchronize your Cozy content with a local folder.
 
 Below are some bonuses 😉
 
-# Hosting more than one cozy instance on the same server
+# Hosting more than one Cozy instance on the same server
 
-Having its own selfhosted cozy instance is nice but hosting cozy instances for friends and familly is a must! Here is how to add more cozy instances on the same server.
+Having its own selfhosted Cozy instance is nice but hosting Cozy instances for friends and familly is a must! Here is how to add more Cozy instances on the same server.
 
-The first cozy instance we added was `https://cozy.domain.example`. We will create a second cozy instance for Mary with address `https://mary.domain.example` (Replace `domain.example` with your own domain name and `mary` whith what you want to uniquely identify the cozy instance.
+The first Cozy instance we added was `https://cozy.domain.example`. We will create a second Cozy instance for Mary with address `https://mary.domain.example` (Replace `domain.example` with your own domain name and `mary` whith what you want to uniquely identify the Cozy instance.
 
 So we will need:
 
 - Our domain name. We still use `domain.example` in this documentation
-- The new cozy instance's “slug”, which is its unique identifier. We will use `mary` here for example. The address for this new cozy instance will the be in the form `https://<slug>.<domain>`, for example here `https://mary.domain.example`
+- The new Cozy instance's “slug”, which is its unique identifier. We will use `mary` here for example. The address for this new Cozy instance will the be in the form `https://<slug>.<domain>`, for example here `https://mary.domain.example`
 
 First, let's put all that important information in variables:
 
@@ -311,12 +311,12 @@ First, let's put all that important information in variables:
     NEWSLUG=mary
     NEWEMAIL=<Mary's email address>
 
-Create DNS entries for this cozy isntance. For example:
+Create DNS entries for this Cozy isntance. For example:
 
     mary     1h     IN         A     <your_server_IP>
     *.mary   1h     IN     CNAME     mary
 
-Create Nginx base configuration for this cozy isntance:
+Create Nginx base configuration for this Cozy isntance:
 
     cat <<EOF | sudo tee /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
     server {
@@ -371,17 +371,17 @@ Finalize Nginx configuration:
     EOF
     sudo systemctl reload nginx
 
-Create cozy instance:
+Create Cozy instance:
 
     [[ -z "${COZY_PASS}" ]] && read -p "Cozy stack admin password: " -r -s COZY_PASS
     COZY_ADMIN_PASSWORD="${COZY_PASS}" cozy-stack instances add --apps home,banks,contacts,drive,notes,passwords,photos,settings,store --email "${NEWEMAIL}" --locale fr --tz "Europe/Paris" ${NEWSLUG}.${DOMAIN}
 
 Note the “Registration token” the last command gives you and send Mary the following url: `https://mary.domain.example?registerToken=<registration_token>`, substituting `domain.example` with your own domain name, `mary` with the slug you chose for this new instance and  `<registration_token>` with the “Registration token” returned by the last command.
-By visiting this address with her browser, Mary will be able to define its password and start using  her cozy.
+By visiting this address with her browser, Mary will be able to define its password and start using her Cozy.
 
 # Online edtion of office documents
 
-Online office document edition functionality based on OnlyOffice is optional. You can use your cozy without activating it. It let you edit your office documents online directly in your browser, however it requires more resources on your server.
+Online office document edition functionality based on OnlyOffice is optional. You can use your Cozy without activating it. It let you edit your office documents online directly in your browser, however it requires more resources on your server.
 
 To activate this functionality, you need to install OnlyOffice document server and configure cozy-stack to access it. OnlyOffice document server can be isntalled on the same server or on another server at your convenience. This documentation explain how to install it on the same server.
 
@@ -484,7 +484,7 @@ You can now upload an office document in cozy-drive and start editing it online 
 
 # Update cozy-stack
 
-Applications inside your cozy are automatically updated, however, cozy-stack application running on your server must be updated from time to time (once every 3 month is a good compromise between too much and too few).
+Applications inside your Cozy are automatically updated, however, cozy-stack application running on your server must be updated from time to time (once every 3 month is a good compromise between too much and too few).
 Here is how to upgrade cozy-stack:
 
 Update source code:

--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
@@ -1,10 +1,10 @@
-# Installation de cozy sous Ubuntu 20.04 LTS focal fossa
+# Installation de Cozy sous Ubuntu 20.04 LTS focal fossa
 
 # Introduction
 
 Cozycloud met à disposition des paquets deb et [des instructions d’installation](https://docs.cozy.io/en/tutorials/selfhosting/selfhost-debian-pkg/) pour Debian 10 buster à partir de ces paquets d’installation. Cependant, il n’y a pas de paquet pour Ubuntu.
 
-Cette documentation décrit donc l’installation de cozy à partir du code source de cozy-stack sur un serveur Ubuntu 20.04 LTS focal fossa. Nous verrons aussi comment activer l’édition en ligne de documents avec onlyoffice.
+Cette documentation décrit donc l’installation de Cozy à partir du code source de cozy-stack sur un serveur Ubuntu 20.04 LTS focal fossa. Nous verrons aussi comment activer l’édition en ligne de documents avec onlyoffice.
 
 
 # Prérequis
@@ -12,9 +12,9 @@ Cette documentation décrit donc l’installation de cozy à partir du code sour
 L’installation nécessite :
 
 - Un serveur sous Ubuntu 20.04 LTS focal fossa
-- Un nom de domaine (indispensable pour héberger les cozy, qu’ils soient accessibles d’internet, et sécurisés en https).
+- Un nom de domaine (indispensable pour héberger les Cozy, qu’ils soient accessibles d’internet, et sécurisés en https).
     Dans la suite de ce document, nous prendrons pour exemple le domaine `domain.example` que vous remplacerez donc par votre propre nom de domaine.
-    Votre cozy aura pour adresse `cozy.domain.example`
+    Votre Cozy aura pour adresse `cozy.domain.example`
 - De bonnes connaissances d’administration système, même si cette documentation se veut la plus simple possible à suivre
 
 De plus, vous aurez besoin de définir au cours de l’installation :
@@ -22,7 +22,7 @@ De plus, vous aurez besoin de définir au cours de l’installation :
 - un mot de passe d’administration pour CouchDB
 - un mot de passe pour l’accès à la base de données CouchDB
 - un mot de passe d’administration pour cozy-stack
-- de fournir votre email pour la création des certificats letsencrypt et la création de votre cozy
+- de fournir votre email pour la création des certificats letsencrypt et la création de votre Cozy
 
 # Couchdb
 
@@ -70,7 +70,7 @@ Puis installez NodeJS :
 
 # Go
 
-Le serveur cozy est développé en Go, nous aurons donc besoin d’installer le compilateur du langage go pour pouvoir compiler depuis les sources :
+Le serveur Cozy est développé en Go, nous aurons donc besoin d’installer le compilateur du langage go pour pouvoir compiler depuis les sources :
 
     wget -O /tmp/go1.17.3.linux-amd64.tar.gz https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
     sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzvf /tmp/go1.17.3.linux-amd64.tar.gz
@@ -269,11 +269,11 @@ Configurez nginx :
     sudo ln -s ../sites-available/cozy.${DOMAIN} /etc/nginx/sites-enabled/
     sudo systemctl reload nginx
 
-Vous pouvez tester depuis votre navigateur en vous rendant à l’adresse `https://cozy.domain.example` et vous devriez alors voir une page vous indiquant que votre cozy n’existe pas. Dans ce cas tout s’est bien passé et il ne reste plus qu’à créer et configurer votre instance de cozy.
+Vous pouvez tester depuis votre navigateur en vous rendant à l’adresse `https://cozy.domain.example` et vous devriez alors voir une page vous indiquant que votre Cozy n’existe pas. Dans ce cas tout s’est bien passé et il ne reste plus qu’à créer et configurer votre instance de Cozy.
 
-# Création de l’instance cozy
+# Création de l’instance Cozy
 
-Pour créer votre instance cozy :
+Pour créer votre instance Cozy:
 
     DOMAIN=domain.example
     EMAIL=<votre email>
@@ -283,25 +283,25 @@ Pour créer votre instance cozy :
 Vous pouvez bien sur adapter la langue (`locale`) et choisir anglais (`en`) ou espagnol (`es`) ou votre timezone (`tz`).
 
 Notez le “Registration token” que vous rend cette dernière commande et accédez depuis votre navigateur à `https://cozy.domain.example?registerToken=<le_token_retourné>` en remplaçant `domain.example` par le nom de votre domaine et ``<le_token_retourné>`` par le “Registration token” retourné par la commande précédente.
-Vous pourrez ainsi définir votre mot de passe et commencer à utiliser votre cozy.
+Vous pourrez ainsi définir votre mot de passe et commencer à utiliser votre Cozy.
 
 # Et voilà !
 
-Votre cozy est désormais opérationnel, profitez-en pleinement ! Son adresse est `https://cozy.domain.example` (remplacez domain.example par votre nom de domaine)
-Vous pouvez commencer à installer depuis le store des connecteurs pour récupérer automatiquement vos données personnelles depuis vos fournisseurs, sauver vos mots de passe dans cozy-pass, entreposer vos fichiers dans cozy-drive et installer notre client en synchronisation sur votre PC pour synchroniser automatiquement le contenu de votre cozy avec un répertoire local.
+Votre Cozy est désormais opérationnel, profitez-en pleinement ! Son adresse est `https://cozy.domain.example` (remplacez domain.example par votre nom de domaine)
+Vous pouvez commencer à installer depuis le store des connecteurs pour récupérer automatiquement vos données personnelles depuis vos fournisseurs, sauver vos mots de passe dans cozy-pass, entreposer vos fichiers dans cozy-drive et installer notre client en synchronisation sur votre PC pour synchroniser automatiquement le contenu de votre Cozy avec un répertoire local.
 
 Et ci-dessous, quelques bonus 😉
 
 # Héberger plusieurs instances sur son serveur
 
-Avoir un cozy auto-hébergé, c’est bien, mais partager et proposer à la famille, aux amis un cozy qu’on héberge pour eux parce qu’on sait faire c’est cool aussi. Voici donc comment créer un autre cozy sur le même serveur.
+Avoir un Cozy auto-hébergé, c’est bien, mais partager et proposer à la famille, aux amis un Cozy qu’on héberge pour eux parce qu’on sait faire c’est cool aussi. Voici donc comment créer un autre Cozy sur le même serveur.
 
-Le premier cozy que nous avons créé a pour adresse `https://cozy.domain.example`. Nous allons créer un second cozy pour Antoinette à l’adresse `https://antoinette.domain.example` (remplacez `domain.example` par votre nom de domaine et `antoinette` par ce que vous voudrez qui identifiera le cozy de manière unique.
+Le premier Cozy que nous avons créé a pour adresse `https://cozy.domain.example`. Nous allons créer un second Cozy pour Antoinette à l’adresse `https://antoinette.domain.example` (remplacez `domain.example` par votre nom de domaine et `antoinette` par ce que vous voudrez qui identifiera le Cozy de manière unique.
 
 Il nous faudra donc :
 
 - Le nom de votre domaine. Nous utilisons toujours `domain.example` dans cette documentation
-- le “slug” du cozy, c’est à dire son identifiant unique. Ici nous utilisons pour l’exemple `antoinette`. L’adresse de votre cozy sera de la forme `https://<slug>.<domain>`, par exmeple ici `https://antoinette.domain.example`
+- le “slug” du Cozy, c’est à dire son identifiant unique. Ici nous utilisons pour l’exemple `antoinette`. L’adresse de votre Cozy sera de la forme `https://<slug>.<domain>`, par exmeple ici `https://antoinette.domain.example`
 
 Nous allons commencer par mettre dans des variables les informations importantes :
 
@@ -310,12 +310,12 @@ Nous allons commencer par mettre dans des variables les informations importantes
     NEWSLUG=antoinette
     NEWEMAIL=<adresse email d'antoinette>
 
-Créer les entrées DNS pour ce cozy. Par exemple :
+Créer les entrées DNS pour ce Cozy. Par exemple :
 
     antoinette     1h     IN         A     <IP_de_votre_serveur>
     *.antoinette   1h     IN     CNAME     antoinette
 
-Créer la configuration de base pour ce cozy dans nginx :
+Créer la configuration de base pour ce Cozy dans nginx :
 
     cat <<EOF | sudo tee /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
     server {
@@ -341,7 +341,7 @@ Générez le certificat SSL à l’aide de certbot :
 
     sudo certbot certonly --email "${EMAIL}" --non-interactive --agree-tos --webroot -w /var/www/html -d ${NEWSLUG}.${DOMAIN} $(printf -- " -d %s.${NEWSLUG}.${DOMAIN}" home banks contacts drive notes passwords photos settings store)
 
-Finalisez la configuration de nginx pour ce nouveau cozy :
+Finalisez la configuration de nginx pour ce nouveau Cozy :
 
     cat <<EOF | sudo tee -a /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
 
@@ -370,20 +370,20 @@ Finalisez la configuration de nginx pour ce nouveau cozy :
     EOF
     sudo systemctl reload nginx
 
-Créer l’instance de cozy :
+Créer l’instance de Cozy :
 
     [[ -z "${COZY_PASS}" ]] && read -p "Cozy stack admin password: " -r -s COZY_PASS
     COZY_ADMIN_PASSWORD="${COZY_PASS}" cozy-stack instances add --apps home,banks,contacts,drive,notes,passwords,photos,settings,store --email "${NEWEMAIL}" --locale fr --tz "Europe/Paris" ${NEWSLUG}.${DOMAIN}
 
-Notez le “Registration token” que vous rend cette dernière commande et envoyez à Antoinette l’url `https://antoinette.domain.example?registerToken=<le_token_retourné>` en remplaçant `domain.example` par le nom de votre domaine, `antoinette` par le slug que vous aurez choisi pour cette nouvelle instance de cozy et `<le_token_retourné>` par le “Registration token” retourné par la commande précédente.
+Notez le “Registration token” que vous rend cette dernière commande et envoyez à Antoinette l’url `https://antoinette.domain.example?registerToken=<le_token_retourné>` en remplaçant `domain.example` par le nom de votre domaine, `antoinette` par le slug que vous aurez choisi pour cette nouvelle instance de Cozy et `<le_token_retourné>` par le “Registration token” retourné par la commande précédente.
 
-En visitant cette adresse à l’aide de son navigateur, elle pourra ainsi définir son mot de passe et commencer à utiliser son cozy.
+En visitant cette adresse à l’aide de son navigateur, elle pourra ainsi définir son mot de passe et commencer à utiliser son Cozy.
 
 # Edition en ligne et collaborative de documents
 
-La fonctionnalité d’édition en ligne de documents basée sur OnlyOffice est optionnelle. Vous pouvez utiliser votre cozy sans l’activer. Elle permet d’éditer en ligne directement dans son navigateur ses documents office mais nécessite des ressources supplémentaires sur votre serveur.
+La fonctionnalité d’édition en ligne de documents basée sur OnlyOffice est optionnelle. Vous pouvez utiliser votre Cozy sans l’activer. Elle permet d’éditer en ligne directement dans son navigateur ses documents office mais nécessite des ressources supplémentaires sur votre serveur.
 
-Pour activer la fonctionnalité d’édition en ligne de documents office, avec onlyoffice, il nous faut installer le serveur de documents onlyoffice et configurer la stack cozy pour y accéder. Le serveur de documents onlyoffice peut être installé sur le même serveur ou sur un serveur différent. Cette documentation expliquer comment le déployer sur le même serveur.
+Pour activer la fonctionnalité d’édition en ligne de documents office, avec onlyoffice, il nous faut installer le serveur de documents onlyoffice et configurer la stack Cozy pour y accéder. Le serveur de documents onlyoffice peut être installé sur le même serveur ou sur un serveur différent. Cette documentation expliquer comment le déployer sur le même serveur.
 
 ## OnlyOffice
 
@@ -480,7 +480,7 @@ Activer la fonctionnalité :
 
 # Mettre à jour cozy-stack
 
-Les applications à l’intérieur de votre cozy se mettent à jour automatiquement, cependant, l’application cozy-stack qui tourne sur votre serveur doit être mise à jour régulièrement (une fois tous les 3 mois environ est un bon compromis entre trop et trop peu).
+Les applications à l’intérieur de votre Cozy se mettent à jour automatiquement, cependant, l’application cozy-stack qui tourne sur votre serveur doit être mise à jour régulièrement (une fois tous les 3 mois environ est un bon compromis entre trop et trop peu).
 Voici la marche à suivre pour y parvenir :
 
 Mettez à jour le code source :

--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
@@ -26,7 +26,7 @@ De plus, vous aurez besoin de définir au cours de l’installation :
 
 # Couchdb
 
-Configurer le dépot de paquets couchdb :
+Configurer le dépôt de paquets couchdb :
 
     sudo apt update && sudo apt install -y curl apt-transport-https gnupg
     curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
@@ -70,7 +70,7 @@ Puis installez NodeJS :
 
 # Go
 
-Le serveur Cozy est développé en Go, nous aurons donc besoin d’installer le compilateur du langage go pour pouvoir compiler depuis les sources :
+Le serveur Cozy est développé en Go, nous aurons donc besoin d’installer le compilateur du langage Go pour pouvoir compiler depuis les sources :
 
     wget -O /tmp/go1.17.3.linux-amd64.tar.gz https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
     sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzvf /tmp/go1.17.3.linux-amd64.tar.gz
@@ -301,7 +301,7 @@ Le premier Cozy que nous avons créé a pour adresse `https://cozy.domain.exampl
 Il nous faudra donc :
 
 - Le nom de votre domaine. Nous utilisons toujours `domain.example` dans cette documentation
-- le “slug” du Cozy, c’est à dire son identifiant unique. Ici nous utilisons pour l’exemple `antoinette`. L’adresse de votre Cozy sera de la forme `https://<slug>.<domain>`, par exmeple ici `https://antoinette.domain.example`
+- le “slug” du Cozy, c’est à dire son identifiant unique. Ici nous utilisons pour l’exemple `antoinette`. L’adresse de votre Cozy sera de la forme `https://<slug>.<domain>`, par exemple ici `https://antoinette.domain.example`
 
 Nous allons commencer par mettre dans des variables les informations importantes :
 

--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
@@ -9,7 +9,7 @@ Cette documentation décrit donc l’installation de cozy à partir du code sour
 
 # Prérequis
 
-L’installation nécessite :
+L’installation nécessite :
 
 - Un serveur sous Ubuntu 20.04 LTS focal fossa
 - Un nom de domaine (indispensable pour héberger les cozy, qu’ils soient accessibles d’internet, et sécurisés en https).
@@ -17,7 +17,7 @@ L’installation nécessite :
     Votre cozy aura pour adresse `cozy.domain.example`
 - De bonnes connaissances d’administration système, même si cette documentation se veut la plus simple possible à suivre
 
-De plus, vous aurez besoin de définir au cours de l’installation :
+De plus, vous aurez besoin de définir au cours de l’installation :
 
 - un mot de passe d’administration pour CouchDB
 - un mot de passe pour l’accès à la base de données CouchDB
@@ -26,25 +26,25 @@ De plus, vous aurez besoin de définir au cours de l’installation :
 
 # Couchdb
 
-Configurer le dépot de paquets couchdb
+Configurer le dépot de paquets couchdb :
 
     sudo apt update && sudo apt install -y curl apt-transport-https gnupg
     curl https://couchdb.apache.org/repo/keys.asc | gpg --dearmor | sudo tee /usr/share/keyrings/couchdb-archive-keyring.gpg >/dev/null 2>&1
     echo "deb [signed-by=/usr/share/keyrings/couchdb-archive-keyring.gpg] https://apache.jfrog.io/artifactory/couchdb-deb/ $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/couchdb.list >/dev/null
 
-Installer Couchdb
+Installer Couchdb :
 
     sudo apt update
     sudo apt install -y couchdb
 
 Lors de l’installation de couchdb, choisir le mode `Standalone` et définir le mot de passe administrateur.
 
-Valider le bon fonctionnement de couchdb
+Valider le bon fonctionnement de couchdb :
 
     curl http://localhost:5984/
     {"couchdb":"Welcome","version":"3.2.1","git_sha":"244d428af","uuid":"f7b83554fa2eb43778963d18a1f92211","features":["access-ready","partitioned","pluggable-storage-engines","reshard","scheduler"],"vendor":{"name":"The Apache Software Foundation"}}
 
-Enfin, créer un utilisateur et un mot de passe pour cozy-stack
+Enfin, créer un utilisateur et un mot de passe pour cozy-stack :
 
     read -p "Couchdb password for cozy user: " -r -s COUCH_PASS
     curl -fsX PUT -u "admin:adminpwd" "http://localhost:5984/_node/couchdb@127.0.0.1/_config/admins/cozy" --data "\"${COUCH_PASS}\""
@@ -55,14 +55,14 @@ Dans cette ligne de commande, `adminpwd` doit être remplacé par le mot de pass
 
 Afin de pouvoir exécuter les connecteurs et qu’ils récupèrent vos données, cozy-stack a besoin de NodeJS version 12 ou 16. Le présent document détaille les informations pour NodeJS 16.
 
- Configurez l’entrepôt de paquets NodeJS
+ Configurez l’entrepôt de paquets NodeJS :
 
     KEYRING=/usr/share/keyrings/nodesource.gpg
     curl -fsSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | sudo tee "$KEYRING" >/dev/null
     echo "deb [signed-by=$KEYRING] https://deb.nodesource.com/node_16.x $(lsb_release -sc) main" | sudo tee /etc/apt/sources.list.d/nodesource.list >/dev/null
     echo "deb-src [signed-by=$KEYRING] https://deb.nodesource.com/node_16.x $(lsb_release -sc) main" | sudo tee -a /etc/apt/sources.list.d/nodesource.list >/dev/null
 
-Puis installez NodeJS
+Puis installez NodeJS :
 
     sudo apt update
     sudo apt install -y nodejs
@@ -70,49 +70,49 @@ Puis installez NodeJS
 
 # Go
 
-Le serveur cozy est développé en Go, nous aurons donc besoin d’installer le compilateur du langage go pour pouvoir compiler depuis les sources
+Le serveur cozy est développé en Go, nous aurons donc besoin d’installer le compilateur du langage go pour pouvoir compiler depuis les sources :
 
     wget -O /tmp/go1.17.3.linux-amd64.tar.gz https://go.dev/dl/go1.17.3.linux-amd64.tar.gz
     sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzvf /tmp/go1.17.3.linux-amd64.tar.gz
     echo "export PATH=\"\$PATH:/usr/local/go/bin\"" | sudo tee /etc/profile.d/golang.sh > /dev/null
     source /etc/profile.d/golang.sh
 
-Tester que l’installation s’est bien déroulée avec
+Tester que l’installation s’est bien déroulée avec :
 
     go version
     go version go1.17.3 linux/amd64
 
 # Cozy-stack
 
-Tout d’abord, Installez les dépendances
+Tout d’abord, Installez les dépendances :
 
     sudo apt install -y imagemagick libprotobuf-c1 fonts-lato
 
-Récupérez le code source
+Récupérez le code source :
 
     sudo apt install -y git
     sudo git clone https://github.com/cozy/cozy-stack.git /opt/cozy-stack
 
-Puis compilez le programme
+Puis compilez le programme :
 
     cd /opt/cozy-stack
     scripts/build.sh release $(go env GOPATH)/bin/cozy-stack
 
 La compilation produit un binaire situé à `$GOPATH/bin/cozy-stack`
 
-Vous pouvez tester la bonne compilation de la façon suivante :
+Vous pouvez tester la bonne compilation de la façon suivante :
 
     $(go env GOPATH)/bin/cozy-stack version
     1.5.0-5-gcbdf012d
 
-Il faut ensuite Créer un utilisateur pour faire fonctionner cozy-stack
+Il faut ensuite Créer un utilisateur pour faire fonctionner cozy-stack :
 
     sudo addgroup --quiet --system cozy
     sudo adduser --quiet --system --home /var/lib/cozy \
                  --no-create-home --shell /usr/sbin/nologin \
                  --ingroup cozy cozy-stack
 
-Puis l’installer
+Puis l’installer :
 
     sudo install -o root -g root -m 0755 -T \
                  $(go env GOPATH)/bin/cozy-stack /usr/bin/cozy-stack
@@ -127,7 +127,7 @@ Puis l’installer
     sudo install -o cozy-stack -g cozy -m 750 -d /var/lib/cozy
 
 
-Et créer la configuration grâce à ces commandes
+Et créer la configuration grâce à ces commandes :
 
     read -p "Cozy stack admin password: " -r -s COZY_PASS
     cat <<EOF | sudo tee /etc/cozy/cozy.yml >/dev/null
@@ -169,7 +169,7 @@ Et créer la configuration grâce à ces commandes
     sudo chown cozy-stack:cozy /etc/cozy/vault.enc /etc/cozy/vault.dec
     sudo chmod 0600 /etc/cozy/vault.enc /etc/cozy/vault.dec
 
-Enfin, configurez le service systemd pour le démarrage automatique
+Enfin, configurez le service systemd pour le démarrage automatique :
 
     cat <<EOF | sudo tee /usr/lib/systemd/system/cozy-stack.service >/dev/null
     [Unit]
@@ -192,30 +192,30 @@ Enfin, configurez le service systemd pour le démarrage automatique
     sudo systemctl enable cozy-stack
     sudo systemctl start cozy-stack
 
-Vous pouvez valider que tout s’est bien passé et que cozy-stack fonctionne bien de la façon suivante :
+Vous pouvez valider que tout s’est bien passé et que cozy-stack fonctionne bien de la façon suivante :
 
     curl http://localhost:8080/version
     {"build_mode":"production","build_time":"2021-12-01T13:12:36Z","runtime_version":"go1.17.3","version":"1.5.0-5-gcbdf012d"}
 
 # Nginx
 
-Commencez par créer une entrée DNS dans votre domaine pour `cozy.domain.example` et `*.cozy.domain.example` qui pointe vers votre serveur. Par exemple :
+Commencez par créer une entrée DNS dans votre domaine pour `cozy.domain.example` et `*.cozy.domain.example` qui pointe vers votre serveur. Par exemple :
 
 
     cozy     1h     IN         A     <IP_de_votre_serveur>
     *.cozy   1h     IN     CNAME     cozy
 
-puis installez Nginx
+puis installez Nginx :
 
     sudo apt install -y nginx certbot
 
-Générez le certificat SSL à l’aide de certbot
+Générez le certificat SSL à l’aide de certbot :
 
     DOMAIN=domain.example
     EMAIL="<votre email>"
     sudo certbot certonly --email "${EMAIL}" --non-interactive --agree-tos --webroot -w /var/www/html -d cozy.${DOMAIN} $(printf -- " -d %s.cozy.${DOMAIN}" home banks contacts drive notes passwords photos settings store)
 
-Pour que le nouveau certificat soit pris en compte automatiquement lors des renouvellements tous les 3 mois, créez le script de rechargement
+Pour que le nouveau certificat soit pris en compte automatiquement lors des renouvellements tous les 3 mois, créez le script de rechargement :
 
     cat <<EOF | sudo tee /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
     #!/bin/bash
@@ -223,7 +223,7 @@ Pour que le nouveau certificat soit pris en compte automatiquement lors des reno
     EOF
     chmod 0755 /etc/letsencrypt/renewal-hooks/deploy/reload-nginx.sh
 
-Configurez nginx
+Configurez nginx :
 
     DOMAIN=domain.example
     cat <<EOF | sudo tee /etc/nginx/sites-available/cozy.${DOMAIN} > /dev/null
@@ -273,7 +273,7 @@ Vous pouvez tester depuis votre navigateur en vous rendant à l’adresse `https
 
 # Création de l’instance cozy
 
-Pour créer votre instance cozy
+Pour créer votre instance cozy :
 
     DOMAIN=domain.example
     EMAIL=<votre email>
@@ -298,24 +298,24 @@ Avoir un cozy auto-hébergé, c’est bien, mais partager et proposer à la fami
 
 Le premier cozy que nous avons créé a pour adresse `https://cozy.domain.example`. Nous allons créer un second cozy pour Antoinette à l’adresse `https://antoinette.domain.example` (remplacez `domain.example` par votre nom de domaine et `antoinette` par ce que vous voudrez qui identifiera le cozy de manière unique.
 
-Il nous faudra donc :
+Il nous faudra donc :
 
 - Le nom de votre domaine. Nous utilisons toujours `domain.example` dans cette documentation
 - le “slug” du cozy, c’est à dire son identifiant unique. Ici nous utilisons pour l’exemple `antoinette`. L’adresse de votre cozy sera de la forme `https://<slug>.<domain>`, par exmeple ici `https://antoinette.domain.example`
 
-Nous allons commencer par mettre dans des variables les informations importantes
+Nous allons commencer par mettre dans des variables les informations importantes :
 
     DOMAIN=domain.example
     EMAIL=<votre adresse email>
     NEWSLUG=antoinette
     NEWEMAIL=<adresse email d'antoinette>
 
-Créer les entrées DNS pour ce cozy. Par exemple :
+Créer les entrées DNS pour ce cozy. Par exemple :
 
     antoinette     1h     IN         A     <IP_de_votre_serveur>
     *.antoinette   1h     IN     CNAME     antoinette
 
-Créer la configuration de base pour ce cozy dans nginx
+Créer la configuration de base pour ce cozy dans nginx :
 
     cat <<EOF | sudo tee /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
     server {
@@ -337,11 +337,11 @@ Créer la configuration de base pour ce cozy dans nginx
     sudo ln -s ../sites-available/${NEWSLUG}.${DOMAIN} /etc/nginx/sites-enabled/
     sudo systemctl reload nginx
 
-Générez le certificat SSL à l’aide de certbot
+Générez le certificat SSL à l’aide de certbot :
 
     sudo certbot certonly --email "${EMAIL}" --non-interactive --agree-tos --webroot -w /var/www/html -d ${NEWSLUG}.${DOMAIN} $(printf -- " -d %s.${NEWSLUG}.${DOMAIN}" home banks contacts drive notes passwords photos settings store)
 
-Finalisez la configuration de nginx pour ce nouveau cozy
+Finalisez la configuration de nginx pour ce nouveau cozy :
 
     cat <<EOF | sudo tee -a /etc/nginx/sites-available/${NEWSLUG}.${DOMAIN} > /dev/null
 
@@ -370,7 +370,7 @@ Finalisez la configuration de nginx pour ce nouveau cozy
     EOF
     sudo systemctl reload nginx
 
-Créer l’instance de cozy
+Créer l’instance de cozy :
 
     [[ -z "${COZY_PASS}" ]] && read -p "Cozy stack admin password: " -r -s COZY_PASS
     COZY_ADMIN_PASSWORD="${COZY_PASS}" cozy-stack instances add --apps home,banks,contacts,drive,notes,passwords,photos,settings,store --email "${NEWEMAIL}" --locale fr --tz "Europe/Paris" ${NEWSLUG}.${DOMAIN}
@@ -405,41 +405,41 @@ La seconde ligne crée un utilisateur de bases de données `onlyoffice` dont le 
 
 ### Installer OnlyOffice Documentserver
 
-Configurer l’entrepôt de paquets
+Configurer l’entrepôt de paquets :
 
     sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
     echo "deb https://download.onlyoffice.com/repo/debian squeeze main" | sudo tee /etc/apt/sources.list.d/onlyoffice.list
     sudo apt update
 
-Installer les polices Microsoft
+Installer les polices Microsoft :
 
     sudo apt install -y ttf-mscorefonts-installer
 
 Lorsque cela vous est demandé, acceptez l’EULA
 
-Installer OnlyOffice Documentserver
+Installer OnlyOffice Documentserver :
 
     sudo apt install -y onlyoffice-documentserver
 
 Lorsque cela vous est demandé, saisissez le mot de passe de base de données créé lors de l’installation de PostgreSQL et la création de la base de données.
 
-Puis redémarrez Nginx
+Puis redémarrez Nginx :
 
     sudo systemctl reload nginx
 
 ### Configurer HTTPS pour OnlyOffice
 
-Créer une entrée DNS pour OnlyOffice qui pointe vers votre serveur. Par exemple :
+Créer une entrée DNS pour OnlyOffice qui pointe vers votre serveur. Par exemple :
 
     onlyoffice     1h     IN         A     <IP_de_votre_serveur>
 
-Créer le certificat
+Créer le certificat :
 
     EMAIL=<votre email>
     DOMAIN=domain.example
     sudo bash /usr/bin/documentserver-letsencrypt.sh "${EMAIL}" "onlyoffice.${DOMAIN}"
 
-Configurer OnlyOffice
+Configurer OnlyOffice :
 
     sudo cp -f /etc/onlyoffice/documentserver/nginx/ds-ssl.conf.tmpl /etc/onlyoffice/documentserver/nginx/ds.conf
 
@@ -450,7 +450,7 @@ Editer le fichier `/etc/onlyoffice/documentserver/nginx/ds.conf` et
 
 Attention, les lignes du fichier de configuration se terminent par des `;`
 
-Redémarrer OnlyOffice et Nginx
+Redémarrer OnlyOffice et Nginx :
 
     sudo supervisorctl restart all
     sudo systemctl restart nginx
@@ -460,7 +460,7 @@ Vous pouvez maintenant tester que onlyoffice est bien accessible depuis votre na
 
 ## Configurer cozy-stack pour OnlyOffice
 
-Mettre à jour le fichier de configuration
+Mettre à jour le fichier de configuration :
 
     DOMAIN=domain.example
     cat <<EOF | sudo tee -a /etc/cozy/cozy.yml > /dev/null
@@ -469,11 +469,11 @@ Mettre à jour le fichier de configuration
         onlyoffice_url: https://onlyoffice.${DOMAIN}/
     EOF
 
-Redémarrer cozy-stack
+Redémarrer cozy-stack :
 
     sudo systemctl restart cozy-stack
 
-Activer la fonctionnalité
+Activer la fonctionnalité :
 
     cozy-stack features defaults '{"drive.onlyoffice.enabled": true}'
 
@@ -481,29 +481,29 @@ Activer la fonctionnalité
 # Mettre à jour cozy-stack
 
 Les applications à l’intérieur de votre cozy se mettent à jour automatiquement, cependant, l’application cozy-stack qui tourne sur votre serveur doit être mise à jour régulièrement (une fois tous les 3 mois environ est un bon compromis entre trop et trop peu).
-Voici la marche à suivre pour y parvenir :
+Voici la marche à suivre pour y parvenir :
 
-Mettez à jour le code source
+Mettez à jour le code source :
 
     cd /opt/cozy-stack
     sudo git pull
 
-Relancer la compilation
+Relancer la compilation :
 
     cd /opt/cozy-stack
     scripts/build.sh release $(go env GOPATH)/bin/cozy-stack
 
-Vous pouvez tester la bonne compilation de la façon suivante :
+Vous pouvez tester la bonne compilation de la façon suivante :
 
     $(go env GOPATH)/bin/cozy-stack version
     1.5.0-9-g1eac6802
 
-Installer le nouveau binaire généré
+Installer le nouveau binaire généré :
 
     sudo install -o root -g root -m 0755 -T \
                  $(go env GOPATH)/bin/cozy-stack /usr/bin/cozy-stack             
 
-Relancer cozy-stack
+Relancer cozy-stack :
 
     sudo systemctl restart cozy-stack
 


### PR DESCRIPTION
Here are some change suggestions on selfhost-ubuntu-sources documentation.

The two commits about colons usage and capitalisation are very subjective so feel free to keep them or to trash them.