### PR TITLE
docs: Fix env variable name for config passwd

### DIFF
--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-en.md
@@ -163,7 +163,7 @@ And create configuration:
     EOF
     sudo chown cozy-stack:cozy /etc/cozy/cozy.yml
     sudo chmod 0644 /etc/cozy/cozy.yml
-    sudo sh -c "COZY_ADMIN_PASSWORD=\"${COZY_PASS}\" cozy-stack config passwd /etc/cozy/cozy-admin-passphrase"
+    sudo sh -c "COZY_ADMIN_PASSPHRASE=\"${COZY_PASS}\" cozy-stack config passwd /etc/cozy/cozy-admin-passphrase"
     sudo chown cozy-stack:cozy /etc/cozy/cozy-admin-passphrase
     sudo cozy-stack config gen-keys /etc/cozy/vault
     sudo chown cozy-stack:cozy /etc/cozy/vault.enc /etc/cozy/vault.dec

--- a/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
+++ b/src/tutorials/selfhosting/selfhost-ubuntu-sources-fr.md
@@ -163,7 +163,7 @@ Et créer la configuration grâce à ces commandes :
     EOF
     sudo chown cozy-stack:cozy /etc/cozy/cozy.yml
     sudo chmod 0644 /etc/cozy/cozy.yml
-    sudo sh -c "COZY_ADMIN_PASSWORD=\"${COZY_PASS}\" cozy-stack config passwd /etc/cozy/cozy-admin-passphrase"
+    sudo sh -c "COZY_ADMIN_PASSPHRASE=\"${COZY_PASS}\" cozy-stack config passwd /etc/cozy/cozy-admin-passphrase"
     sudo chown cozy-stack:cozy /etc/cozy/cozy-admin-passphrase
     sudo cozy-stack config gen-keys /etc/cozy/vault
     sudo chown cozy-stack:cozy /etc/cozy/vault.enc /etc/cozy/vault.dec


### PR DESCRIPTION
See cmd/config.go. The environment variable it looks for is COZY_ADMIN_PASSPHRASE, not COZY_ADMIN_PASSWORD.