### PR TITLE
docs: Fix cozy-app-publish source repo

### DIFF
--- a/OUTSIDE_DOCS
+++ b/OUTSIDE_DOCS
@@ -1,4 +1,4 @@
-cozy-app-publish https://github.com/cozy/cozy-app-publish.git .
+cozy-app-publish https://github.com/cozy/cozy-libs.git packages/cozy-app-publish
 cozy-apps-registry https://github.com/cozy/cozy-apps-registry.git .
 cozy-client https://github.com/cozy/cozy-client.git docs
 cozy-ui https://github.com/cozy/cozy-ui.git docs


### PR DESCRIPTION
Fix cozy-app-publish repo URL from obsolete repo to subfolder of cozy-libs repo