### PR TITLE
docs: Enhance howto setup stack for konnectors dev

### DIFF
--- a/src/howTos/dev/run-connectors-on-local-cozy-stack.md
+++ b/src/howTos/dev/run-connectors-on-local-cozy-stack.md
@@ -4,21 +4,62 @@ title: How to run connectors with a local cozy-stack
 
 Running connectors to test them with a local cozy-stack gives a quick feedback loop but requires a little setup.
 
-## Prerequisite
+### Prerequisite
 
 - Have a local cozy-stack installed
 - Have NodeJS installed at the system level
 
-## Configure your local cozy-stack
+### Copy the default config file if not already done
 
-Your local cozy-stack needs to know where to find the connectors runner on your filesystem. To this end, you'll need to [download the script](https://raw.githubusercontent.com/cozy/cozy-stack/master/scripts/konnector-node-run.sh) from the [cozy-stack repository](https://github.com/cozy/cozy-stack) (or clone the entire repository) and then set the path in your `cozy.yaml` file as such:
+Create a directory  `~/.cozy` and copy the default configuration file into it. Be careful, the file name and location matter, as explained in the [config documentation](https://docs.cozy.io/en/cozy-stack/config/).
 
-```yaml
-# This top-level key might already exist if you used the template from the 
-# cozy-stack repository
-konnectors:
-  cmd: <absolute path to konnector-node-run.sh>
- 
+```bash
+cp cozy-stack/cozy.example.yaml ~/.cozy/cozy.yaml`
 ```
 
-You can now restart your local cozy-stack and install your connector (for more information on how to run a connector from a local directory, check the [connectors tutorial](https://docs.cozy.io/en/tutorials/konnector/save-data/)).
+### Edit the config file
+
+Edit the file `~/.cozy/cozy.yaml` and change the line after the `konnectors:` entry to have this:
+
+```yaml
+cmd: /home/alice/.cozy/scripts/konnector-node-run.sh
+```
+
+### Create the script to execute the service
+
+Copy the file `cozy-stack/scripts/konnector-node-run.sh` to `~/.cozy/konnector-node-run.sh`:
+
+Then you need to `chmod +x ~/.cozy/scripts/konnector-node-run.sh`
+
+Be sure to have `node` in your `/usr/bin` or `/usr/local/bin` folder. If not, you can add a symlink to `node` in one of those folder, for example by typing `ln -s $(which node) /usr/local/bin/node`
+
+### Get your service logs in a isolated file
+
+Edit your `~/.cozy/konnector-node-run.sh` by adding a tee output.
+
+```bash
+node "${arg}" | tee -a ~/.cozy/services.log
+```
+
+Now you can `tail -f ~/.cozy/services.log` to watch logs in real time.
+
+## Install your konnector
+
+To install the konnector containing the service on your local stack, you must give the path of your build:
+
+```bash
+cozy-stack konnector install <konnector_name> file://<build_path>
+# Example:
+# cozy-stack apps install ameli file:///home/alice/ameli/build
+```
+
+Each time you make modifications to your builded konnector, you must update the app on the stack to propagate the changes:
+
+```bash
+cozy-stack konnectors update <konnector_name>
+```
+
+
+## Konnector is a service anyway
+
+As a konnector is subtype of service in cozy, you can look at a more global documentation here: [Develop a service](https://docs.cozy.io/en/howTos/dev/services/)

--- a/src/howTos/dev/services.md
+++ b/src/howTos/dev/services.md
@@ -15,7 +15,7 @@ You can find an example of an existing service in the [cozy-banks app](https://g
 
 ## CozyClient instantiation
 
-By using `fromEnv`, you will be able to use the service in dev mode (via cozy-konnector-dev see [Execution](#execution)) or in production. 
+By using `fromEnv`, you will be able to use the service in dev mode (via cozy-konnector-dev see [Execution](#execution)) or in production.
 
 ```js
 const client = CozyClient.fromEnv(process.env, { schema })
@@ -64,7 +64,7 @@ Some configuration is required to execute the service and store the produced log
 
 In the following, we assume that your `$HOME` is /home/alice, so change accordingly to your own `$HOME`.
 
-### Copy the default config file
+### Copy the default config file if not already done
 
 Create a directory  `~/.cozy` and copy the default configuration file into it. Be careful, the file name and location matter, as explained in the [config documentation](https://docs.cozy.io/en/cozy-stack/config/).
 
@@ -86,21 +86,21 @@ cmd: /home/alice/.cozy/scripts/konnector-node-run.sh
 url: file:///home/alice/.cozy/storage
 ```
 
-### Create the script to store the logs
+### Create the script to execute the service
 
-Create the file `~/.cozy/scripts/konnector-node-run.sh`:
-
-```bash
-#!/bin/bash
-
-rundir="${1}"
-cd $rundir
-node index.js | tee ~/.cozy/services.log
-```
+Copy the file `cozy-stack/scripts/konnector-node-run.sh` to `~/.cozy/konnector-node-run.sh`:
 
 Then you need to `chmod +x ~/.cozy/scripts/konnector-node-run.sh`
 
 Be sure to have `node` in your `/usr/bin` or `/usr/local/bin` folder. If not, you can add a symlink to `node` in one of those folder, for example by typing `ln -s $(which node) /usr/local/bin/node`
+
+### Get your service logs in a isolated file
+
+Edit your `~/.cozy/konnector-node-run.sh` by adding a tee output.
+
+```bash
+node "${arg}" | tee -a ~/.cozy/services.log
+```
 
 Now you can `tail -f ~/.cozy/services.log` to watch logs in real time.
 
@@ -110,6 +110,8 @@ To install the app containing the service on your local stack, you must give the
 
 ```bash
 cozy-stack apps install <app_name> file://<build_path>
+# Example:
+# cozy-stack apps install banks file:///home/alice/cozy-banks/build
 ```
 
 Each time you make modifications to your service, you must update the app on the stack to propagate the changes:


### PR DESCRIPTION
A little update, discussed with @paultranvan and @KillianCourvoisier 

This PR do :

Update the part concerning konnector-node-run script
-> Use the example in repo of cozy-stack and not a script in the docs
-> Separate the script creation and isolation of logs

Explicit the need of three slash in the example.

Remove a trailing space
