### PR TITLE
feat: Link to orga not doc repo

### DIFF
--- a/mkdocs.yml.tpl
+++ b/mkdocs.yml.tpl
@@ -3,7 +3,7 @@ docs_dir: src
 site_url: https://docs.cozy.io/
 site_dir: docs/en
 site_favicon: img/favicon.png
-repo_url: https://github.com/cozy/cozy.github.io/
+repo_url: https://github.com/cozy/
 edit_uri: edit/dev/src/
 site_description: Cozy documentation
 site_author: CozyCloud - https://cozy.io


### PR DESCRIPTION
We prefer to redirect the user to our organization page with all our repos instead of just the doc's
repo.
<img width="604" alt="Capture d’écran 2023-04-13 à 08 19 04" src="https://user-images.githubusercontent.com/1107936/231671817-f9d03612-1915-4d3c-8f20-791184bce2da.png">
