### PR TITLE
fix: Fix edit link of the first page

### DIFF
--- a/mkdocs.yml.tpl
+++ b/mkdocs.yml.tpl
@@ -4,7 +4,7 @@ site_url: https://docs.cozy.io/
 site_dir: docs/en
 site_favicon: img/favicon.png
 repo_url: https://github.com/cozy/
-edit_uri: edit/dev/src/
+edit_uri: cozy.github.io/edit/dev/src
 site_description: Cozy documentation
 site_author: CozyCloud - https://cozy.io
 extra_css:


### PR DESCRIPTION
Since 90c124f2952f8d19a580284d2dfb1417a889730a the link on the edit icon was not working anymore since the URL was not right.

Let's fix that.