### PR TITLE
docs: Update services.md

### DIFF
--- a/src/howTos/dev/services.md
+++ b/src/howTos/dev/services.md
@@ -99,6 +99,7 @@ Be sure to have `node` in your `/usr/bin` or `/usr/local/bin` folder. If not, yo
 Edit your `~/.cozy/konnector-node-run.sh` by adding a tee output.
 
 ```bash
+set -o pipefail
 node "${arg}" | tee -a ~/.cozy/services.log
 ```
 


### PR DESCRIPTION
> The exit status of a pipeline is the exit status of the last command in the pipeline, unless the pipefail option is enabled (see The Set Builtin). If pipefail is enabled, the pipeline's return status is the value of the last (rightmost) command to exit with a non-zero status, or zero if all commands exit successfully.

Since tee exits 0, even if the service was failing, the result was 0.