### PR TITLE
tech: Allow building with Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ pytz==2018.5
 PyYAML==6.0
 requests==2.20.0
 sh==1.12.14
-six==1.11.0
+six==1.16.0
 terminaltables==3.1.0
 tornado==6.0
 transifex-client

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ requests==2.20.0
 sh==1.12.14
 six==1.11.0
 terminaltables==3.1.0
-tornado==5.1.1
+tornado==6.0
 transifex-client
 tx==0.0.1
 Unidecode==1.0.22

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ Click==7.0
 colorclass==2.2.0
 docopt==0.6.2
 idna==2.7
-Jinja2==2.10.1
+Jinja2==2.10.2
 jsx-lexer==0.0.6
 livereload==2.5.2
 Markdown==3.2.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,13 +5,13 @@ Click==7.0
 colorclass==2.2.0
 docopt==0.6.2
 idna==2.7
-Jinja2==2.10
+Jinja2==2.10.1
 jsx-lexer==0.0.6
 livereload==2.5.2
-Markdown==3.2
+Markdown==3.2.1
 markdown-i18n==2.1.2
 MarkupSafe==1.1
-packaging==18.0
+packaging==20.5
 pip-upgrader==1.4.6
 Pygments==2.2.0
 pyparsing==2.2.2
@@ -27,7 +27,7 @@ transifex-client
 tx==0.0.1
 Unidecode==1.0.22
 urllib3==1.24.2
-mkdocs==1.0.4
+mkdocs==1.2.3
 mkdocs-material==4.4.0
 mkdocs-exclude==1.0.2
 mkdocs-exclude-search==0.5.4


### PR DESCRIPTION
Some dependencies cannot be installed with Python 3.12 and others make
use of old Python features which are not available anymore and prevent
us from building the project. This PR sets to upgrade those dependencies
to make building the project with Python 3.12 possible.