### PR TITLE
chore: Add Manual workflow & cron

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [ dev ]
   pull_request:
     branches: [ dev ]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 3 * * *'
 
 jobs:
   lint:


### PR DESCRIPTION
With workflow_dispatch, we can now deploy manually the documentation

With the schedule, we'll deploy every day the documentation. 

Since end of February, the documentation was not published automatically anymore.